### PR TITLE
Retain state when doing partial rebuild

### DIFF
--- a/nix-hive.go
+++ b/nix-hive.go
@@ -45,7 +45,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	err = applyState()
+	err = applyState(args)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prevents `nix-hive build somesystem` from deleting all systems other than `somesystem`.