### PR TITLE
package nix-hive as a flake, switch from nixfmt to nixpkgs-fmt

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,17 @@
 # From the current directory: nix-env -if .
 # 
 # There is also an overlay in nix/overlay.nix, a simple package in nix/package.nix and a nix shell in shell.nix.
-{ nixpkgs ? <nixpkgs> }:
-let pkgs = import nixpkgs { overlays = [ (import nix/overlay.nix) ]; };
-in pkgs.hive
+#
+# Note that this uses https://github.com/edolstra/flake-compat to pass emulate Nix flakes, even on Nix releases without flake support.
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url =
+        "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666135017,
+        "narHash": "sha256-imG3gOTGHLTupZ016kc5gVdgjMKMthb4tI4pMyYiV40=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b29e6c7218374775626b8f08479aec6795f16d28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
+    flake-compat.url = "github:edolstra/flake-compat";
+    flake-compat.flake = false;
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    {
+      overlays = {
+        default = final: prev: {
+          hive = prev.callPackage ./nix/package.nix { };
+        };
+      };
+    } // flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages = rec {
+          default = hive;
+          hive = pkgs.callPackage ./nix/package.nix { inherit pkgs system; };
+        };
+        devShells = {
+          default = pkgs.mkShell {
+            name = "nix-hive-shell";
+            buildInputs = with pkgs; [ go nixpkgs-fmt nix ];
+            shellHook = ''
+              # We inject <hive> into your path to support local development.
+              export NIX_PATH="hive=$PWD/nix/hive:$NIX_PATH"
+
+              nixfmtAll() { find . -name '*.nix' -exec nixpkgs-fmt -- {} +; }
+            '';
+          };
+        };
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,12 @@
-{ nixpkgs ? <nixpkgs>, pkgs ? import nixpkgs { } }:
-let pkgs = import nixpkgs { };
-in pkgs.mkShell {
-  name = "nix-hive-shell";
-  buildInputs = with pkgs; [ go nixfmt nix ];
-  shellHook = ''
-    # We inject <hive> into your path to support local development.
-    export NIX_PATH="hive=./nix/hive:$NIX_PATH"
-  '';
-  # TODO: add chore for:
-  #   nixfmt -w 120 *.nix (find example nix -name '*.nix')
-}
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
Retains original usage while adding `nix run`, `nix develop` &c.