### PR TITLE
update for nixpkgs 24.05, use vendorHash in place of vendorSha256

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,16 +33,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666135017,
-        "narHash": "sha256-imG3gOTGHLTupZ016kc5gVdgjMKMthb4tI4pMyYiV40=",
+        "lastModified": 1724717301,
+        "narHash": "sha256-QoJrQ4k0ZW3kOwJruvsLWVGdC3t9XMOfmzXO0dGlM1g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b29e6c7218374775626b8f08479aec6795f16d28",
+        "rev": "901b587393cee8d9d0f61d5f20850558ca127e85",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-22.05",
+        "ref": "release-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
     flake-compat.url = "github:edolstra/flake-compat";
     flake-compat.flake = false;
     flake-utils.url = "github:numtide/flake-utils";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,7 +3,7 @@ buildGoModule {
   name = "nix-hive";
 
   src = ./..;
-  vendorSha256 = "17sdj4h84q9d22s2j2qx3xrlfpg206x3wlgmq9xfnmk55bzxiidr";
+  vendorHash = "sha256:17sdj4h84q9d22s2j2qx3xrlfpg206x3wlgmq9xfnmk55bzxiidr";
   nativeBuildInputs = [ makeWrapper ];
 
   postFixup = ''


### PR DESCRIPTION
This PR updates the nixpkgs used to 24.04 and replaces the deprecated `vendorSha256` with `vendorHash`
